### PR TITLE
Fix implicit integer to float promotions in binary operators

### DIFF
--- a/src/qiskit_qasm3_import/expression.py
+++ b/src/qiskit_qasm3_import/expression.py
@@ -17,7 +17,7 @@ scope, rather than trying to build a whole new internal IR to handle everything 
 
 __all__ = ["ValueResolver", "resolve_condition"]
 
-from typing import Any, Iterable, Mapping, Tuple, Union, cast
+from typing import Any, Iterable, Tuple, Union, cast
 
 from openqasm3 import ast
 from openqasm3.visitor import QASMVisitor

--- a/src/qiskit_qasm3_import/expression.py
+++ b/src/qiskit_qasm3_import/expression.py
@@ -17,7 +17,7 @@ scope, rather than trying to build a whole new internal IR to handle everything 
 
 __all__ = ["ValueResolver", "resolve_condition"]
 
-from typing import Any, Iterable, Mapping, Tuple, Union
+from typing import Any, Iterable, Mapping, Tuple, Union, cast
 
 from openqasm3 import ast
 from openqasm3.visitor import QASMVisitor
@@ -29,6 +29,7 @@ from .data import Symbol
 
 
 _IntegerT = Union[types.Never, types.Int, types.Uint]
+_NumericT = Union[types.Uint, types.Int, types.Float]
 
 
 def join_integer_types(left: _IntegerT, right: _IntegerT) -> _IntegerT:
@@ -45,6 +46,19 @@ def join_integer_types(left: _IntegerT, right: _IntegerT) -> _IntegerT:
     if isinstance(left, types.Uint) and isinstance(right, types.Uint):
         return types.Uint(const, size)
     return types.Int(const, size)
+
+
+def join_numeric_types(left: _NumericT, right: _NumericT) -> _NumericT:
+    const = left.const and right.const
+    if isinstance(left, types.Float) and isinstance(right, types.Float):
+        size = None if left.size is None or right.size is None else max((left.size, right.size))
+        return types.Float(const, size)
+    if isinstance(left, types.Float):
+        return types.Float(const, left.size)
+    if isinstance(right, types.Float):
+        return types.Float(const, right.size)
+    # Cast because this can't return the never type since neither of the inputs are never.
+    return cast(_NumericT, join_integer_types(left, right))
 
 
 class ValueResolver(QASMVisitor):
@@ -162,81 +176,59 @@ class ValueResolver(QASMVisitor):
             raise_from_node(node, f"unsupported binary operation '{node.op.name}'")
         lhs_value, lhs_type = self.visit(node.lhs)
         rhs_value, rhs_type = self.visit(node.rhs)
+        out_type: Union[None, types.Type] = None
+
+        # First, handle the simple implicit promotion rules for the standard numeric types (i.e. not
+        # angle).
+        numeric_t = (types.Int, types.Uint, types.Float)
+        if isinstance(lhs_type, numeric_t) and isinstance(rhs_type, numeric_t):
+            out_type = join_numeric_types(lhs_type, rhs_type)
 
         if node.op.name in ("+", "-"):
-            if isinstance(lhs_type, (types.Int, types.Uint)) and isinstance(
-                rhs_type, (types.Int, types.Uint)
-            ):
-                out_type = join_integer_types(lhs_type, rhs_type)
-                out_value = (
-                    lhs_value + rhs_value
-                    if node.op is ast.BinaryOperator["+"]
-                    else lhs_value - rhs_value
-                )
-                return out_value, out_type
-            if isinstance(lhs_type, (types.Float, types.Angle)) and type(lhs_type) == type(
-                rhs_type
-            ):
+            if isinstance(lhs_type, types.Angle) and isinstance(rhs_type, types.Angle):
                 const = lhs_type.const and rhs_type.const
                 size = (
                     None
                     if lhs_type.size is None or rhs_type.size is None
                     else max((lhs_type.size, rhs_type.size))
                 )
+                out_type = types.Angle(const, size)
+            if out_type is not None:
                 out_value = (
                     lhs_value + rhs_value
                     if node.op is ast.BinaryOperator["+"]
                     else lhs_value - rhs_value
                 )
-                return out_value, type(lhs_type)(const, size)
+                return out_value, out_type
 
         elif node.op is ast.BinaryOperator["/"]:
-            if isinstance(rhs_type, (types.Int, types.Uint)):
-                if isinstance(lhs_type, (types.Int, types.Uint)):
-                    return lhs_value // rhs_value, join_integer_types(lhs_type, rhs_type)
-                if isinstance(lhs_type, types.Float):
+            if isinstance(lhs_type, types.Angle):
+                if isinstance(rhs_type, (types.Int, types.Uint)):
                     const = lhs_type.const and rhs_type.const
-                    return lhs_value / rhs_value, types.Float(const, lhs_type.size)
-                if isinstance(lhs_type, types.Angle):
+                    out_type = types.Angle(const, lhs_type.size)
+                elif isinstance(rhs_type, types.Angle):
                     const = lhs_type.const and rhs_type.const
-                    return lhs_value / rhs_value, types.Angle(const, lhs_type.size)
-            elif isinstance(lhs_type, types.Angle):
-                if isinstance(rhs_type, types.Angle):
-                    const = lhs_type.const and rhs_type.const
-                    if const:
-                        return int(lhs_value / rhs_value), types.Uint(const=const)
-                    return lhs_value / rhs_value, types.Uint(const=const)
-                # Already handled integer rhs.
-            elif isinstance(lhs_type, types.Float):
-                if isinstance(rhs_type, types.Float):
-                    const = lhs_type.const and rhs_type.const
-                    size = (
-                        None
-                        if lhs_type.size is None or rhs_type.size is None
-                        else max((lhs_type.size, rhs_type.size))
-                    )
-                    return lhs_value / rhs_value, types.Float(const, size)
+                    out_type = types.Uint(const, None)
+            if out_type is not None:
+                out_value = (
+                    lhs_value // rhs_value
+                    if isinstance(out_type, (types.Int, types.Uint)) and out_type.const
+                    else lhs_value / rhs_value
+                )
+                return out_value, out_type
 
         elif node.op is ast.BinaryOperator["*"]:
-            if isinstance(rhs_type, (types.Int, types.Uint)):
-                if isinstance(lhs_type, (types.Int, types.Uint)):
-                    return lhs_value * rhs_value, join_integer_types(lhs_type, rhs_type)
-                if isinstance(lhs_type, types.Float):
-                    const = lhs_type.const and rhs_type.const
-                    return lhs_value * rhs_value, types.Float(const, lhs_type.size)
-                if isinstance(lhs_type, types.Angle):
-                    const = lhs_type.const and rhs_type.const
-                    return lhs_value * rhs_value, types.Angle(const, lhs_type.size)
-            elif isinstance(lhs_type, types.Float):
-                # Already handled integer rhs.
-                if isinstance(rhs_type, types.Float):
-                    const = lhs_type.const and rhs_type.const
-                    size = (
-                        None
-                        if lhs_type.size is None or rhs_type.size is None
-                        else max((lhs_type.size, rhs_type.size))
-                    )
-                    return lhs_value * rhs_value, types.Float(const, size)
+            if (
+                isinstance(lhs_type, types.Angle) and isinstance(rhs_type, (types.Int, types.Uint))
+            ) or (
+                isinstance(rhs_type, types.Angle) and isinstance(lhs_type, (types.Int, types.Uint))
+            ):
+                const = lhs_type.const and rhs_type.const
+                size = lhs_type.size if isinstance(lhs_type, types.Angle) else rhs_type.size
+                out_type = types.Angle(const, size)
+            if out_type is not None:
+                out_value = lhs_value * rhs_value
+                return out_value, out_type
 
         return None, types.Error()
 

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -265,9 +265,13 @@ def test_unary_minus_rejects_bad_types():
         ("+", types.Int(True, 4), types.Int(False, 3), types.Int(False, 4)),
         ("+", types.Int(True, 4), types.Int(False, None), types.Int(False, None)),
         ("+", types.Float(True, None), types.Float(False, 64), types.Float(False, None)),
+        ("+", types.Int(True, None), types.Float(True, 64), types.Float(True, 64)),
+        ("+", types.Float(True, None), types.Uint(False, 32), types.Float(False, None)),
         ("+", types.Angle(True, None), types.Angle(False, 8), types.Angle(False, None)),
         ("-", types.Uint(True, 4), types.Int(False, 3), types.Int(False, 4)),
         ("-", types.Uint(True, 4), types.Uint(False, None), types.Uint(False, None)),
+        ("-", types.Int(True, None), types.Float(True, 64), types.Float(True, 64)),
+        ("-", types.Float(True, None), types.Uint(False, 32), types.Float(False, None)),
         ("-", types.Float(True, 64), types.Float(True, 64), types.Float(True, 64)),
         ("-", types.Angle(True, 4), types.Angle(True, 8), types.Angle(True, 8)),
         ("/", types.Int(True, 5), types.Uint(True, None), types.Int(True, None)),
@@ -280,6 +284,8 @@ def test_unary_minus_rejects_bad_types():
         ("*", types.Float(True, 64), types.Int(False, None), types.Float(False, 64)),
         ("*", types.Angle(True, 8), types.Int(False, None), types.Angle(False, 8)),
         ("*", types.Float(False, 64), types.Float(True, None), types.Float(False, None)),
+        ("*", types.Int(True, None), types.Float(True, 64), types.Float(True, 64)),
+        ("*", types.Float(True, None), types.Uint(False, 32), types.Float(False, None)),
     ),
     ids=lambda x: x.pretty() if isinstance(x, types.Type) else x,
 )
@@ -301,7 +307,6 @@ def test_binary_operator(op, left_type, right_type, out_type):
 @pytest.mark.parametrize(
     ("op", "left_type", "right_type"),
     (
-        ("+", types.Int(True, 3), types.Float(True, 4)),
         ("+", types.Duration(True), types.Float(True, 64)),
         ("+", types.Int(True, 4), types.Angle(True, 4)),
         ("-", types.Angle(True, 4), types.Float(True, 64)),


### PR DESCRIPTION
This permits expressions such as `3 * pi / 4`; the OpenQASM 3 specification defers to the C promotion rules, which allow this. Previously they were incorrectly forbidden by this converter.

Fix #6.

This addition to the type resolver is still just a huge hack around the AST we're building against not having any "implicit cast" nodes in it, and I'm still hoping to entirely replace this package in the near future, but this is a stop-gap measure to fix a bug reported against Terra.