### PR TITLE
Update openqasm3[parser] requirement from <0.5.0,>=0.4.0 to >=0.4.0,<0.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
     = src
 install_requires =
     qiskit-terra>=0.21.0
-    openqasm3[parser]>=0.4,<0.5
+    openqasm3[parser]>=0.4,<0.6
 
 [options.packages.find]
 where = src/


### PR DESCRIPTION
Updating `openqasm3` requirement to allow `openqasm3==0.5.0`.