### PR TITLE
Add support for `!` on scalar `bit` types

### DIFF
--- a/releasenotes/notes/add-exclamation-support-2b89d9fa0e7359cf.yaml
+++ b/releasenotes/notes/add-exclamation-support-2b89d9fa0e7359cf.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Boolean negation using the ``!`` operator on scalar ``bit`` types is now supported.

--- a/src/qiskit_qasm3_import/expression.py
+++ b/src/qiskit_qasm3_import/expression.py
@@ -326,7 +326,7 @@ def resolve_condition(
             raise_from_node(node, "only '==' is supported in register comparisons")
         return (bit_value, cmp_value)
     if isinstance(node, ast.UnaryExpression):
-        if node.op is not ast.UnaryOperator["~"]:
+        if node.op not in (ast.UnaryOperator["~"], ast.UnaryOperator["!"]):
             raise_from_node(node, f"unhandled unary operator '{node.op.name}'")
         value, type = value_resolver.visit(node.expression)
         if isinstance(type, types.Bit):

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -65,13 +65,14 @@ def test_implicit_bit():
     assert resolve_condition(node, context) == (bit, True)
 
 
-def test_implicit_negated_bit():
+@pytest.mark.parametrize("op", ("~", "!"))
+def test_implicit_negated_bit(op):
     bit = Clbit()
     symbols = [
         Symbol("a", bit, types.Bit(), Scope.GLOBAL),
     ]
     context = _make_context(symbols)
-    node = ast.UnaryExpression(ast.UnaryOperator["~"], ast.Identifier("a"))
+    node = ast.UnaryExpression(ast.UnaryOperator[op], ast.Identifier("a"))
     assert resolve_condition(node, context) == (bit, False)
 
 


### PR DESCRIPTION
It's not 100% clear from the OQ3 spec whether this is permitted, but Qiskit certainly outputs using this, the IBM QE stack allows this, and it generally sensible.

Fix #14