### PR TITLE
Update dependencies to reflect new Qiskit structure

### DIFF
--- a/releasenotes/notes/new-dependencies-8832b75aecf57205.yaml
+++ b/releasenotes/notes/new-dependencies-8832b75aecf57205.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    This package now depends on `qiskit>=0.37,<1.0` instead of `qiskit-terra>=0.21`.  This reflects
+    how the Qiskit package is now structured, with the lower bound referring to the same version of
+    Terra.  This package is due to cease being the preferred OpenQASM 3 importer for Qiskit around
+    the 1.0, but the upper bound is more specifically because the package is not yet guaranteeing
+    that it will support all the changes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 package_dir =
     = src
 install_requires =
-    qiskit-terra>=0.21.0
+    qiskit>=0.37.0,<1.0
     openqasm3[parser]>=0.4,<0.6
 
 [options.packages.find]


### PR DESCRIPTION
The preferred install path for Qiskit is now the `qiskit` Python package, and the "component" `qiskit-terra` is no longer preferred and expected to be removed with Qiskit 1.0.  This updates the dependencies to refer to the minimum supported version of the `qiskit` package instead; the lowest version of that will now install more than is completely required, but all latest versions are correct, and will be correct moving forwards.