### PR TITLE
Add licence headers

### DIFF
--- a/src/qiskit_qasm3_import/__init__.py
+++ b/src/qiskit_qasm3_import/__init__.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 """Basic importer for OpenQASM 3 programmes into Qiskit."""
 
 __version__ = "0.4.1"

--- a/src/qiskit_qasm3_import/api.py
+++ b/src/qiskit_qasm3_import/api.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import openqasm3
 from qiskit import QuantumCircuit
 

--- a/src/qiskit_qasm3_import/converter.py
+++ b/src/qiskit_qasm3_import/converter.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 __all__ = ["ConvertVisitor"]
 
 import re

--- a/src/qiskit_qasm3_import/data.py
+++ b/src/qiskit_qasm3_import/data.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import enum
 from typing import Any, Optional
 from openqasm3 import ast

--- a/src/qiskit_qasm3_import/exceptions.py
+++ b/src/qiskit_qasm3_import/exceptions.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 from typing import NoReturn, Optional
 
 from openqasm3 import ast

--- a/src/qiskit_qasm3_import/expression.py
+++ b/src/qiskit_qasm3_import/expression.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 """QASM visitors for the expression tree, resolving it into objects that are useful for interaction
 with Qiskit.
 

--- a/src/qiskit_qasm3_import/state.py
+++ b/src/qiskit_qasm3_import/state.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import re
 import enum
 from typing import Optional, Union

--- a/src/qiskit_qasm3_import/types.py
+++ b/src/qiskit_qasm3_import/types.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import abc
 import typing
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import pytest
 
 from openqasm3 import ast

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import math
 
 import numpy as np

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,3 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
+
 import operator
 
 import pytest


### PR DESCRIPTION
This matches other Qiskit projects.  They originally weren't in these files because the project wasn't originally going to be managed by the Qiskit organisation, but was just a proof of concept.