### PR TITLE
Fix layout output with hardware qubits

### DIFF
--- a/releasenotes/notes/fix-layout-holes-becf2dd6b849c066.yaml
+++ b/releasenotes/notes/fix-layout-holes-becf2dd6b849c066.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Importing a circuit with physical qubits (for example ``$4``) will now create a
+    :class:`~qiskit.circuit.QuantumCircuit` that has as many qubits as implied by the maximum
+    physical-qubit index encountered.  For example, if the largest physical qubit encountered is
+    ``$4``, the output circuit will have five qubits.
+
+    Previously, the circuit would only have as many qubit objects as were explicitly used and the
+    :class:`~qiskit.transpiler.TranspileLayout` of the circuit would attempt to indicate the mapping,
+    but this was at odds with how Qiskit typically represents physical circuits, and the returned
+    layout was in a non-standard form.


### PR DESCRIPTION
This fixes the output of programs that involve hardware qubits to the form more standard to how Qiskit represents physical circuits.  Now, the output circuit will have as many qubits as the maximum hardware qubit explicitly used, even if the lower qubits are not used.  The `TranspileLayout` will be a mapping of the qubits to their own indices, to indicate that there were no underlying virtual qubits, but to assist with other tools in recognising that the circuit is defined on physical qubits.

The previous handling of hardware qubits created a circuit with only explicitly referenced qubits in the circuit, then attempted to convey the information about the actual hardware indices via the `TranspileLayout`.  Unfortunately, this was not in a form that was readily understandable to other tools, and the model of the "physical" circuit not directly having its bit indices correspond to the hardware qubit index was at odds with Qiskit's usual model of physical circuits.

Fix #28

---

@jyu00: the resulting circuit won't be full device width (that would need an extra kwarg for the parser), but it'll match the expected behaviour that the _used_ qubit indices in the dumped and loaded circuits will be the same.  This appears to be fine through `backend.run` paths, and it's not rejected out-of-hand by `EstimatorV2`, but my test job of that on Peekskill (`cqr71bd00evg008cxarg`) just span its wheels stuck in "Running", so I cancelled it.  This is the setup I used:
```python
import re
from qiskit.circuit.random import random_circuit
from qiskit import QuantumCircuit, qasm2, qasm3, transpile
from qiskit_ibm_runtime import QiskitRuntimeService

service = QiskitRuntimeService()
backend = service.backend("ibm_peekskill")

random_circ = random_circuit(5, depth=3, seed=42).decompose(reps=3)
transpiled = transpile(random_circ, backend=backend, seed_transpiler=64, initial_layout=range(10, 15))

loaded = qasm3.loads(qasm3.dumps(transpiled))

# This works regardless of whether the full width is present:
assert loaded.num_qubits < backend.num_qubits
job = backend.run(loaded)
```