### PR TITLE
Avoid private methods when adding unused `Parameter`s

### DIFF
--- a/releasenotes/notes/parameter-hack-0ce14b3bf824981d.yaml
+++ b/releasenotes/notes/parameter-hack-0ce14b3bf824981d.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    The internal-only method of handling circuits that define a parameter that they do not use
+    (such as a program that defines ``input float a;`` but doesn't use ``a``) has changed to
+    avoid using private Qiskit methods.  This makes it more resilient to changing versions
+    of Qiskit.
+upgrade:
+  - |
+    OpenQASM 3 inputs that include ``input float`` parameters that are not used by the program
+    will now parse to circuits that have a global phase that appears parametrised in terms of
+    the otherwise-unused parameter.  The numerical value of the global phase will not be affected,
+    and the global phase will be independent of the parameters.  You can discard the parameter
+    by using ``QuantumCircuit.assign_parameters`` to assign any numeric value to the parameter.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -340,6 +340,15 @@ def test_input_defines_parameter():
     assert qc == expected
 
 
+def test_unused_input_defines_parameter():
+    source = """
+        input float a;
+    """
+    qc = parse(source)
+    assert len(qc.parameters) == 1
+    assert qc.parameters[0].name == "a"
+
+
 def test_invalid_register_names_are_escaped():
     """Terra as of 0.22 only allows registers with valid OQ2 identifiers as names.  This restriction
     may be relaxed following Qiskit/qiskit-terra#9100."""
@@ -513,6 +522,22 @@ def test_parametrised_gate_definition():
     expected.u(0, 4.5, 0, 0)
     expected.cx(0, 1)
     assert qc.data[0].operation.definition == expected
+
+
+def test_parametrised_gate_without_use():
+    # Test that a gate parametrised on an angle that's not actually used in the gate body works.
+    source = """
+        include 'stdgates.inc';
+        qubit q;
+        gate my_gate(p) a {
+            x a;
+        }
+        my_gate(0.5) q;
+    """
+    qc = parse(source)
+    assert len(qc.data) == 1
+    assert qc.data[0].operation.name == "my_gate"
+    assert qc.data[0].qubits == tuple(qc.qubits)
 
 
 def test_gate_cannot_redefine():


### PR DESCRIPTION
Using private methods of `QuantumCircuit` to force tracking of unused `Parameter` instances resulting in the cleanest circuit output, but was fragile against Qiskit changing the private data structure internals. This has been a real problem as Qiskit moves more of the internal data tracking down to Rust space.

This changes the hacked-in tracking to use only public methods to insert a dummy reference, at the cost that a _true_ reference is added in to the global phase.  For most real-world uses of unused parameters (i.e. those in gate bodies), this will immediately be assigned out and so be invisible to users.  The only place where this should appear to users is if there is an `input float` that is unused.  In these cases, a dummy reference will be inserted into the global phase that has no effect.

Fix #33.