### PR TITLE
Allow float/angle interaction in gate-parameter contexts

### DIFF
--- a/releasenotes/notes/float-context-1a05941c69c21bdd.yaml
+++ b/releasenotes/notes/float-context-1a05941c69c21bdd.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Gate-parameter contexts now permit ``float`` and ``angle`` types to interact via multiplication
+    and division.  Strictly this is against the OpenQASM 3 specification, but in practice, Qiskit
+    often outputs this kind of expression during its OpenQASM 3 exports, because of problems in how
+    symbolic parameters are represented in Qiskit.  This parser will now accept such statements to
+    work around the technically invalid OpenQASM 3 output by Qiskit.

--- a/releasenotes/notes/float-context-1a05941c69c21bdd.yaml
+++ b/releasenotes/notes/float-context-1a05941c69c21bdd.yaml
@@ -5,4 +5,4 @@ features:
     and division.  Strictly this is against the OpenQASM 3 specification, but in practice, Qiskit
     often outputs this kind of expression during its OpenQASM 3 exports, because of problems in how
     symbolic parameters are represented in Qiskit.  This parser will now accept such statements to
-    work around the technically invalid OpenQASM 3 output by Qiskit.
+    work around the technically invalid OpenQASM 3 output by Qiskit, if ``strict=False``.

--- a/src/qiskit_qasm3_import/expression.py
+++ b/src/qiskit_qasm3_import/expression.py
@@ -218,6 +218,13 @@ class ValueResolver(QASMVisitor):
                     else max((lhs_type.size, rhs_type.size))
                 )
                 out_type = types.Angle(const, size)
+            elif not self._strict and (
+                (isinstance(lhs_type, types.Angle) and isinstance(rhs_type, types.Float))
+                or (isinstance(rhs_type, types.Angle) and isinstance(lhs_type, types.Float))
+            ):
+                const = lhs_type.const and rhs_type.const
+                size = lhs_type.size if isinstance(lhs_type, types.Angle) else rhs_type.size
+                out_type = types.Angle(const, size)
             if out_type is not None:
                 out_value = (
                     lhs_value + rhs_value

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -339,7 +339,8 @@ def test_binary_operator(op, left_type, right_type, out_type):
     (
         ("+", types.Duration(True), types.Float(True, 64), None),
         ("+", types.Int(True, 4), types.Angle(True, 4), None),
-        ("-", types.Angle(True, 4), types.Float(True, 64), None),
+        ("-", types.Float(True, None), types.Angle(False, None), types.Angle(False, None)),
+        ("-", types.Angle(True, 4), types.Float(True, 64), types.Angle(True, 4)),
         ("-", types.Uint(True, 4), types.Angle(False, 3), None),
         ("*", types.Angle(True, 4), types.Angle(True, 4), None),
         ("*", types.Angle(True, 4), types.Float(True, None), types.Angle(True, 4)),


### PR DESCRIPTION
This allows technically invalid OpenQASM 3, but is in practice what Qiskit's OpenQASM 3 exporter outputs due to problems in how it represents symbolic expressions.  It's probably better for users to allow the technically invalid OpenQASM 3 than to punish them for things that are actually Qiskit's fault.

Fix #25.