### PR TITLE
Add release notes to docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ release = qiskit_qasm3_import.__version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "reno.sphinxext",
     'qiskit_sphinx_theme',
 ]
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,8 @@ OpenQASM 3 Importer for Qiskit
 .. toctree:: 
     :hidden: 
  
-    Home <self>
+    API documentation <self>
+    release_notes
 
 .. module:: qiskit_qasm3_import
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,0 +1,7 @@
+.. _release-notes:
+
+=============
+Release notes
+=============
+
+.. release-notes::


### PR DESCRIPTION
The release notes were always written, just not hooked into the actual Sphinx structure.