### PR TITLE
Bump openqasm3[parser] dependency to >=0.4,<2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
     = src
 install_requires =
     qiskit>=0.37.0
-    openqasm3[parser]>=0.4,<0.6
+    openqasm3[parser]>=0.4,<1.1.0
 
 [options.packages.find]
 where = src/

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ package_dir =
     = src
 install_requires =
     qiskit>=0.37.0
-    openqasm3[parser]>=0.4,<1.1.0
+    openqasm3[parser]>=0.4,<2.0
 
 [options.packages.find]
 where = src/


### PR DESCRIPTION
- Loosen `openqasm3[parser]` dependency so that this package no longer creates dependency conflict with [openqasm3 v1.0.0](https://pypi.org/project/openqasm3/1.0.0/)