### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/releasenotes/notes/prepare-0.5.1-f850197b84546664.yaml
+++ b/releasenotes/notes/prepare-0.5.1-f850197b84546664.yaml
@@ -1,0 +1,4 @@
+---
+prelude: >
+    `qiskit-qasm3-import` version 0.5.1 increases the supported versions of the underlying `openqasm3`
+    parser package to reflect the semantic-versioned stability guarantees following its 1.0 release.

--- a/src/qiskit_qasm3_import/__init__.py
+++ b/src/qiskit_qasm3_import/__init__.py
@@ -11,7 +11,7 @@
 
 """Basic importer for OpenQASM 3 programmes into Qiskit."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = ["parse", "convert", "ConversionError"]
 


### PR DESCRIPTION
The only user-facing change is that the requirements on the `openqasm3` package are now much wider, since it is semver stable.  Little meaningful changed between its version 0.4 and its 1.0 release, for us at least.