### PR TITLE
Run tests against Qiskit `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.13']
 
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +76,43 @@ jobs:
           set -e
           py=${{ matrix.python-version }}
           tox -e py${py/./}
+
+  tests-main:
+    name: Run tests (main)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: 'qasm3-import'
+
+      - uses: actions/checkout@v4
+        with:
+          path: 'qiskit'
+          repository: 'Qiskit/qiskit'
+          ref: 'main'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Prepare Python environment
+        run: pip install --upgrade pip tox build
+
+      - name: Build Qiskit
+        working-directory: 'qiskit'
+        run: python -m build --wheel .
+
+      - name: Run tests 
+        working-directory: 'qasm3-import'
+        run: |
+          set -e
+          shopt -s failglob
+          py=${{ matrix.python-version }}
+          env="py${py/./}"
+          tox -e $env --notest
+          .tox/$env/bin/pip install ../qiskit/dist/qiskit-2*.whl
+          tox -e $env
 
   deploy-docs:
     name: Deploy documentation

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -854,7 +854,7 @@ def test_delay():
     qc = parse(source)
     expected = QuantumCircuit([Qubit()], QuantumRegister(2, name="qr"))
     expected.delay(10, 0, unit="dt")
-    expected.delay(1, [1, 2], unit="s")
+    expected.delay(1.0, [1, 2], unit="s")
     expected.delay(1.5, unit="ms")
     assert qc == expected
 


### PR DESCRIPTION
This is mostly temporary to have a version of the test suite that runs against the upcoming Qiskit 2.  This will enable testing of some new features that will only be supported from that version onwards.

Close #40.