### PR TITLE
Configure CI to run in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   lint:


### PR DESCRIPTION
I've configured the branch-protection rules here to require this, so no other PRs but this one can merge yet.