### PR TITLE
Add version-parts tuple

### DIFF
--- a/releasenotes/notes/version-parts-5a9abe8806e97a0a.yaml
+++ b/releasenotes/notes/version-parts-5a9abe8806e97a0a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    A data object in the package root, ``VERSION_PARTS``, is now available.
+    This is a tuple of ``int``, representing the major, minor and patch versions.

--- a/src/qiskit_qasm3_import/__init__.py
+++ b/src/qiskit_qasm3_import/__init__.py
@@ -12,6 +12,7 @@
 """Basic importer for OpenQASM 3 programmes into Qiskit."""
 
 __version__ = "0.5.1"
+VERSION_PARTS = (0, 5, 1)
 
 __all__ = ["parse", "convert", "ConversionError"]
 


### PR DESCRIPTION
Since the API will be expanding a little in new versions, this makes it easier for Qiskit to do some simple capability negotiation in the versioning.