### PR TITLE
Add support for annotated boxes in Qiskit 2.1

### DIFF
--- a/releasenotes/notes/box-annotations-f6c6739668a833db.yaml
+++ b/releasenotes/notes/box-annotations-f6c6739668a833db.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :func:`.convert` and :func:`.parse` now have a ``annotation_handlers`` keyword argument, which
+    can be used in conjunction with :class:`~qiskit.circuit.annotation.OpenQASM3Serializer` objects
+    from Qiskit 2.1+ to deserialize custom annotations for ``box`` statements.

--- a/src/qiskit_qasm3_import/api.py
+++ b/src/qiskit_qasm3_import/api.py
@@ -9,19 +9,51 @@
 # Any modifications or derivative works of this code must retain this copyright notice, and modified
 # files need to carry a notice indicating that they have been altered from the originals.
 
+from __future__ import annotations
+
+import typing
+
 import openqasm3
 from qiskit import QuantumCircuit
 
 from .converter import ConvertVisitor
 
+if typing.TYPE_CHECKING:
+    from qiskit.circuit import annotation
 
-def convert(node: openqasm3.ast.Program) -> QuantumCircuit:
+
+def convert(
+    node: openqasm3.ast.Program,
+    *,
+    annotation_handlers: dict[str, annotation.OpenQASM3Serializer] | None = None,
+) -> QuantumCircuit:
     """Convert a parsed OpenQASM 3 program in AST form, into a Qiskit
-    :class:`~qiskit.circuit.QuantumCircuit`."""
-    return ConvertVisitor().convert(node).circuit
+    :class:`~qiskit.circuit.QuantumCircuit`.
+
+    :param annotation_handlers: A mapping whose values are the (de)serializers of custom annotation
+        objects, and whose associated key is a parent of all the namespaces that that deserializer
+        can handle.  The corresponding Qiskit functionality was only added in Qiskit 2.1.
+
+    .. versionadded:: 0.6.0
+        The ``annotation_handlers`` parameter.
+    """
+    return ConvertVisitor(annotation_handlers=annotation_handlers).convert(node).circuit
 
 
-def parse(string: str, /) -> QuantumCircuit:
+def parse(
+    string: str,
+    /,
+    *,
+    annotation_handlers: dict[str, annotation.OpenQASM3Serializer] | None = None,
+) -> QuantumCircuit:
     """Wrapper around :func:`.convert`, which first parses the OpenQASM 3 program into AST form, and
-    then converts the output to Qiskit format."""
-    return convert(openqasm3.parse(string))
+    then converts the output to Qiskit format.
+
+    :param annotation_handlers: A mapping whose values are the (de)serializers of custom annotation
+        objects, and whose associated key is a parent of all the namespaces that that deserializer
+        can handle.  The corresponding Qiskit functionality was only added in Qiskit 2.1.
+
+    .. versionadded:: 0.6.0
+        The ``annotation_handlers`` parameter.
+    """
+    return convert(openqasm3.parse(string), annotation_handlers=annotation_handlers)


### PR DESCRIPTION
This uses the custom OpenQASM 3 serialisers defined in Qiskit 2.1 (along with the entire annotation frameworkd, defined in that release) to handle annotated boxes and pass them along to Qiskit.

Built on top of #47.

Tests of Qiskit `main` will fail until Qiskit/qiskit#14439 is merged.